### PR TITLE
Removed useless commas and fixed regexp to resurrect mona

### DIFF
--- a/scripts/communication.js
+++ b/scripts/communication.js
@@ -9,7 +9,7 @@ const incomingGreetings = [
   'G\'day',
   '\^Hi\$',
   'Morning',
-  'Hey',
+  'Hey'
 ];
 
 const responsesOnName = [
@@ -17,7 +17,7 @@ const responsesOnName = [
   'How can I help?',
   'Yeap?)',
   'Mm?)',
-  "I'm here)",
+  "I'm here)"
 ];
 
 const responsesOnGreeting = [
@@ -26,7 +26,7 @@ const responsesOnGreeting = [
   'Nice... :smiley:',
   'Hello! :smiley:',
   'Morning, :smiley:',
-  'Hi, how are you?',
+  'Hi, how are you?'
 ];
 
 const handlerCommunication = (robot, queries, answers) => {
@@ -40,6 +40,6 @@ module.exports = (robot) => {
   handlerCommunication(
     robot,
     incomingGreetings,
-    responsesOnGreeting,
+    responsesOnGreeting
   );
 };

--- a/scripts/order_water.js
+++ b/scripts/order_water.js
@@ -81,14 +81,14 @@ const respondWithOrderConfirmation = (response) => {
     'Ok.',
     'I will!',
     'Done :white_check_mark:.',
-    'Yes!',
+    'Yes!'
   ];
   response.reply(response.random(possibleReplies));
 };
 
 const respondWithOrderSendingError = (response) => {
   const possibleReplies = [
-    'Something went wrong and request hasn\'t been sent. :non-potable_water:',
+    'Something went wrong and request hasn\'t been sent. :non-potable_water:'
   ];
   response.reply(response.random(possibleReplies));
 };
@@ -103,7 +103,7 @@ const respondWithTooMuchOrdersError = (response, robot) => {
 
 const handlerCommunication = (robot, queries) => {
   queries.forEach((query) => {
-    robot.hear(new RegExp(query, 'i'), (response) => {
+    robot.hear(new RegExp(`^${query}$`, 'i'), (response) => {
       if (passedEnoughTimeFromLastOrder(robot)) {
         sendOrderToWaterDealer(
           robot,
@@ -112,7 +112,7 @@ const handlerCommunication = (robot, queries) => {
           },
           () => {
             respondWithOrderSendingError(response);
-          },
+          }
         );
       } else {
         respondWithTooMuchOrdersError(response, robot);


### PR DESCRIPTION
As it turned out Heroku don't like commas in the end of arrays and objects.
Also returned `^${query}$` as it was before instead of just `query`
![image](https://user-images.githubusercontent.com/32716983/58249529-d0d16c80-7d67-11e9-900a-63166d340955.png)
