### PR TITLE
Replaced {} by () in order to fix tests

### DIFF
--- a/specs/greeting_spec.js
+++ b/specs/greeting_spec.js
@@ -13,12 +13,12 @@ describe('Sample hears controller', () => {
 
   it(
     'Should return any greeting if user types `hi`',
-    () => {
+    () => (
       this.bot.usersInput([{
         messages: [{
           text: 'hi', isAssertion: true,
         }],
       }]).then(message => assert(replies.includes(message.text)))
-    },
+    ),
   )
 })

--- a/specs/mention_spec.js
+++ b/specs/mention_spec.js
@@ -13,13 +13,13 @@ describe('Mention controller', () => {
 
   it(
     'should return one of mention responds if user mentions bot',
-    () => {
+    () => (
       this.bot.usersInput([{
         type: 'direct_mention',
         messages: [{
           text: 'bot', isAssertion: true,
         }],
       }]).then(message => assert(replies.includes(message.text)))
-    },
+    ),
   )
 })


### PR DESCRIPTION
Fix#44
BEFORE
```
it(
    'should return one of mention responds if user mentions bot',
    () => {
      this.bot.usersInput([{
        type: 'direct_mention',
        messages: [{
          text: 'bot', isAssertion: true,
        }],
      }]).then(message => assert(replies.includes("something wrong")))
    },
  )
```
![image](https://user-images.githubusercontent.com/32716983/58569746-5f019300-823f-11e9-8fcf-27cdded7fc4d.png)
AFTER
```
it(
    'should return one of mention responds if user mentions bot',
    () => (
      this.bot.usersInput([{
        type: 'direct_mention',
        messages: [{
          text: 'bot', isAssertion: true,
        }],
      }]).then(message => assert(replies.includes("something wrong")))
    ),
  )
```
![image](https://user-images.githubusercontent.com/32716983/58569677-40030100-823f-11e9-818a-3ecb8e9ca3ad.png)
